### PR TITLE
update WIFIonICE URLs which are currently used

### DIFF
--- a/woice/woice.py
+++ b/woice/woice.py
@@ -10,10 +10,10 @@ import lxml.html
 
 
 # login URL of the wifi on ice portal
-LOGIN_URL = "http://www.wifionice.de/de/"
+LOGIN_URL = "https://login.wifionice.de/de/"
 
 # url to get used data volume
-USAGE_URL = "http://www.wifionice.de/usage_info/"
+USAGE_URL = "https://login.wifionice.de/usage_info/"
 
 # set user agent
 HEADERS = {


### PR DESCRIPTION
The current master branch is at the moment not working for me. As I am currently on the train I tested what has changed. The following changes have been necessary:

* DB has relocated the login page to login.wifionice.de. 
   Visiting wifionice.de results in a redirect to an informational page with the hint that the login page has moved.
* The request should directly use https://
   Not only does this remove an unnecessary redirect, but the `woice down` command will otherwise not work for me.

With these changes the command is again working for me!

